### PR TITLE
DependabotのPRの自動マージ有効化にPATではなくGitHub Appを使うように

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,12 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Get GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
       - name: Get dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
@@ -21,10 +27,10 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT_FOR_DEPENDABOT_AUTO_MERGE }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Enable auto-merge (semver-minor)
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.PAT_FOR_DEPENDABOT_AUTO_MERGE }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
- DependabotのPRの自動マージ有効化にPATではなくGitHub Appを使うように